### PR TITLE
Build for Java 8

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 #Wed May 13 19:53:57 KST 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bullshtml 1.1
+# bullshtml 1.2.1
 Html Reporter for BullseyeCoverage tool. 
 This project has been forked from google code as the original author seems to no longer maintain the project.
 This project has been enhanced to support newer version of Bullseye and properly show branch coverage.

--- a/build.xml
+++ b/build.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project basedir="." default="build" name="bullshtml">
 	<property environment="env" />
-	<property name="target" value="1.5" />
-	<property name="source" value="1.5" />
+	<property name="target" value="1.8" />
+	<property name="source" value="1.8" />
 	<property name="version" value="1.2.0" />
 	<property name="package.dir" value="target" />
 	<property name="antlib.dir" value="antlib" />

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 	<property environment="env" />
 	<property name="target" value="1.8" />
 	<property name="source" value="1.8" />
-	<property name="version" value="1.2.0" />
+	<property name="version" value="1.2.1" />
 	<property name="package.dir" value="target" />
 	<property name="antlib.dir" value="antlib" />
 	<property name="lib.dir" value="lib" />

--- a/releasenote.txt
+++ b/releasenote.txt
@@ -1,4 +1,7 @@
 = BullsHTML Release Note =
+    * 1.2.1(2020.11.20)
+      - Generate Java 8 bytecode for Java 15 compatibility
+
     * 1.2.0(2016.07.06)
       - Strip also displayed paths with -s option
 

--- a/target/bullshtml.jsmooth
+++ b/target/bullshtml.jsmooth
@@ -15,7 +15,7 @@
 <mainClassName>com.simontuffs.onejar.Boot</mainClassName>
 <maximumMemoryHeap>-1</maximumMemoryHeap>
 <maximumVersion></maximumVersion>
-<minimumVersion>1.5</minimumVersion>
+<minimumVersion>1.8</minimumVersion>
 <skeletonName>Console Wrapper</skeletonName>
 <skeletonProperties>
 <key>Message</key>


### PR DESCRIPTION
Hello,

latest OpenJDK 15 javac is not compatible with source targeted to Java 5:

```
    [javac] error: Source option 5 is no longer supported. Use 7 or later.
    [javac] error: Target option 5 is no longer supported. Use 7 or later.
```

Let's use Java 8 as a baseline.

Could you please merge and create a 1.2.1 release?

Thanks,
Gregor